### PR TITLE
Add domain `avatars.githubusercontent.com`

### DIFF
--- a/socket_query.py
+++ b/socket_query.py
@@ -20,6 +20,7 @@ def output_hosts():
                 'avatars6.githubusercontent.com',
                 'avatars7.githubusercontent.com',
                 'avatars8.githubusercontent.com',
+                'avatars.githubusercontent.com',
                 'github.githubassets.com',
                 'user-images.githubusercontent.com',
                 'codeload.github.com',


### PR DESCRIPTION
Hi @nICEnnnnnnnLee , It seems that the address of avatars have migrated to `avatars.githubusercontent.com`. For example there is a demo avatar: <https://avatars.githubusercontent.com/u/6422482>.