### PR TITLE
Add domain `marketplace-screenshots.githubusercontent.com`

### DIFF
--- a/socket_query.py
+++ b/socket_query.py
@@ -25,6 +25,7 @@ def output_hosts():
                 'user-images.githubusercontent.com',
                 'codeload.github.com',
                 'favicons.githubusercontent.com',
+                'marketplace-screenshots.githubusercontent.com',
                 'api.github.com'
                 ]
     


### PR DESCRIPTION
Hi @nICEnnnnnnnLee , It seems that the picture on the market-place pages can't be parsed.

For example: <https://marketplace-screenshots.githubusercontent.com/30/bd604a00-50e1-11eb-8703-004a87792985?auto=webp&format=jpeg&width=670&dpr=2>